### PR TITLE
Split registration binary 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,9 +6,9 @@ steps:
       system: x86_64-linux
 
     command:
-      - 'nix-build -A votingToolsTarball'
+      - 'nix-build -A voterRegistrationTarball'
     artifact_paths:
-      - "result/voting-tools.tar.gz"
+      - "result/voter-registration.tar.gz"
     agents:
       system: x86_64-linux
 

--- a/cabal.project
+++ b/cabal.project
@@ -2,8 +2,12 @@ index-state: 2020-11-15T00:00:00Z
 
 packages:
   ./.
+  ./registration
 
 package voting-tools
+  tests: True
+
+package voter-registration
   tests: True
 
 package cardano-api

--- a/default.nix
+++ b/default.nix
@@ -23,14 +23,14 @@ let
   haskellPackagesMusl64 = recRecurseIntoAttrs
     # the Haskell.nix package set, reduced to local packages.
     (selectProjectPackages pkgs.pkgsCross.musl64.votingToolsHaskellPackages);
-  votingToolsTarball = pkgs.runCommandNoCC "voting-tools-tarball" { buildInputs = [ pkgs.gnutar gzip ]; } ''
-    cp ${haskellPackagesMusl64.voting-tools.components.exes.voting-tools}/bin/voting-tools ./
+  voterRegistrationTarball = pkgs.runCommandNoCC "voter-registration-tarball" { buildInputs = [ pkgs.gnutar gzip ]; } ''
+    cp ${haskellPackagesMusl64.voter-registration.components.exes.voter-registration}/bin/voter-registration ./
     mkdir -p $out
-    tar -czvf $out/voting-tools.tar.gz voting-tools
+    tar -czvf $out/voter-registration.tar.gz voter-registration
   '';
 
   self = {
-    inherit votingToolsHaskellPackages votingToolsTarball;
+    inherit votingToolsHaskellPackages voterRegistrationTarball;
     inherit haskellPackages hydraEvalErrors;
 
     inherit (pkgs.iohkNix) checkCabalProject;

--- a/registration/LICENSE
+++ b/registration/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/registration/src/Main.hs
+++ b/registration/src/Main.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Main where
+
+import           Cardano.API (ShelleyBasedEra (ShelleyBasedEraShelley))
+import           Cardano.Api.Protocol (Protocol (CardanoProtocol), withlocalNodeConnectInfo)
+import           Cardano.Api.Typed (AsType (AsStakeAddress), Hash, Lovelace (Lovelace),
+                     StakeCredential (StakeCredentialByKey), StakeKey, makeStakeAddress,
+                     serialiseToBech32, serialiseToRawBytesHex)
+import           Cardano.Chain.Slotting (EpochSlots (..))
+import           Cardano.CLI.Types (QueryFilter (FilterByAddress), SocketPath (SocketPath))
+import qualified Cardano.Crypto.DSIGN as Crypto
+import           Control.Monad.Except (ExceptT, MonadError, runExceptT, throwError)
+import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.Logger (logInfoN, runNoLoggingT, runStderrLoggingT,
+                     runStdoutLoggingT)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Encode.Pretty as Aeson
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.ByteString.Lazy.Char8 as BLC
+import           Data.Function ((&))
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import           Data.Text (Text)
+import qualified Data.Text as T
+import qualified Options.Applicative as Opt
+
+import           Cardano.API.Extended (readEnvSocketPath)
+import           Cardano.CLI.Fetching (Fund, chunkFund, fundFromVotingFunds)
+import           Cardano.CLI.Voting (createVoteRegistration, encodeVoteRegistration, prettyTx,
+                     signTx)
+import           Cardano.CLI.Voting.Error (AppError)
+import           Cardano.CLI.Voting.Metadata (voteSignature)
+import           Cardano.CLI.Voting.Signing (verificationKeyRawBytes)
+import           Config
+import qualified Config.Genesis as Genesis
+import qualified Config.Registration as Register
+import qualified Config.Rewards as Rewards
+import           Genesis (decodeGenesisTemplateJSON, getBlockZeroDate, setBlockZeroDate,
+                     setInitialFunds)
+
+main :: IO ()
+main = do
+  regOpts <- Opt.execParser Register.opts
+  eCfg    <- runExceptT (Register.mkConfig regOpts)
+  case eCfg of
+    Left (err :: Register.ConfigError) ->
+      fail $ show err
+    Right (Register.Config addr voteSign paySign votePub networkId ttl outFile) -> do
+      eResult <- runExceptT $ do
+        SocketPath sockPath <-  readEnvSocketPath
+        withlocalNodeConnectInfo (CardanoProtocol $ EpochSlots 21600) networkId sockPath $ \connectInfo -> do
+          -- Create a vote registration, encoding our registration
+          -- as transaction metadata. The transaction sends some
+          -- unspent ADA back to us (minus a fee).
+
+          -- Generate vote payload (vote information is encoded as metadata).
+          let vote = createVoteRegistration voteSign votePub
+
+          -- Encode the vote as a transaction and sign it
+          voteRegistrationTx <- signTx paySign <$> encodeVoteRegistration connectInfo ShelleyBasedEraShelley addr ttl vote
+
+          -- Output helpful information
+          liftIO . putStrLn $ "Vote public key used        (hex): " <> BSC.unpack (serialiseToRawBytesHex votePub)
+          liftIO . putStrLn $ "Stake public key used       (hex): " <> BSC.unpack (verificationKeyRawBytes voteSign)
+          liftIO . putStrLn $ "Vote registration signature (hex): " <> BSC.unpack (Base16.encode . Crypto.rawSerialiseSigDSIGN $ voteSignature vote)
+
+          -- Output our vote transaction
+          liftIO . writeFile outFile $ prettyTx voteRegistrationTx
+      case eResult of
+        Left  (err :: AppError) -> fail $ show err
+        Right ()                -> pure ()

--- a/registration/voter-registration.cabal
+++ b/registration/voter-registration.cabal
@@ -1,0 +1,58 @@
+cabal-version:       >=1.10
+name:                voter-registration
+version:             0.1.0.0
+-- synopsis:
+-- description:
+-- bug-reports:
+-- license:
+license-file:        LICENSE
+author:              Samuel Evans-Powell
+maintainer:          mail@sevanspowell.net
+-- copyright:
+-- category:
+build-type:          Simple
+extra-source-files:  ../CHANGELOG.md
+
+executable voter-registration
+  main-is:             Main.hs
+  build-depends:       base
+                     , aeson
+                     , aeson-pretty
+                     , unordered-containers
+                     , attoparsec
+                     , base16-bytestring
+                     , bech32
+                     , bytestring
+                     , conduit
+                     , lens-aeson
+                     , binary
+                     , cardano-api
+                     , cardano-binary
+                     , cardano-cli
+                     , cardano-crypto-class
+                     , cardano-ledger
+                     , cardano-crypto
+                     , containers
+                     , time
+                     , resourcet
+                     , monad-logger
+                     , monoidal-containers
+                     , lens
+                     , mtl
+                     , nothunks
+                     , cardano-ledger-shelley-ma
+                     , optparse-applicative
+                     , ouroboros-consensus
+                     , ouroboros-consensus-cardano
+                     , ouroboros-consensus-shelley
+                     , ouroboros-network
+                     , ouroboros-network-framework
+                     , safe-exceptions
+                     , shelley-spec-ledger
+                     , scientific
+                     , text
+                     , transformers-except
+                     , voting-tools
+
+  hs-source-dirs:      src/
+  default-language:    Haskell2010

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -13,15 +13,13 @@ import qualified Config.Registration as Register
 import qualified Config.Rewards as Rewards
 
 data Command
-  = Register Register.Opts
-  | Genesis Genesis.Opts
+  = Genesis Genesis.Opts
   | Rewards Rewards.Opts
   deriving (Eq, Show)
 
 parseOpts :: Parser Command
 parseOpts = hsubparser
-  (  command "register" (Register <$> Register.opts)
-  <> command "genesis"  (Genesis  <$> Genesis.opts)
+  (  command "genesis"  (Genesis  <$> Genesis.opts)
   <> command "rewards"  (Rewards  <$> Rewards.opts)
   )
 

--- a/src/Config/Common.hs
+++ b/src/Config/Common.hs
@@ -1,7 +1,6 @@
 module Config.Common where
 
 import qualified Data.ByteString.Char8 as BC
-import           Database.Persist.Postgresql (ConnectionString)
 import           Options.Applicative (Parser, auto, help, long, metavar, option)
 
 import           Cardano.Api.Typed (SlotNo (SlotNo))
@@ -12,9 +11,6 @@ data DatabaseConfig
                    , _dbHost       :: String
                    }
   deriving (Eq, Show)
-
-pgConnectionString :: DatabaseConfig -> ConnectionString
-pgConnectionString (DatabaseConfig dbName dbUser dbHost) = BC.pack $ "host=" <> dbHost <> " dbname=" <> dbName <> " user=" <> dbUser
 
 pSlotNo :: Parser SlotNo
 pSlotNo = SlotNo

--- a/src/Config/Genesis.hs
+++ b/src/Config/Genesis.hs
@@ -20,7 +20,6 @@ import qualified Data.ByteString.Char8 as BC
 import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
-import           Database.Persist.Postgresql (ConnectionString)
 
 import           Options.Applicative
 

--- a/src/Config/Rewards.hs
+++ b/src/Config/Rewards.hs
@@ -10,7 +10,6 @@ import qualified Data.ByteString.Char8 as BC
 import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
-import           Database.Persist.Postgresql (ConnectionString)
 
 import           Options.Applicative
 

--- a/voting-tools.cabal
+++ b/voting-tools.cabal
@@ -20,7 +20,6 @@ library
                      , Cardano.API.Extended.Raw
                      , Cardano.API.Jormungandr
                      , Cardano.CLI.Fetching
-                     , Cardano.CLI.Query
                      , Cardano.CLI.Voting
                      , Cardano.CLI.Voting.Error
                      , Cardano.CLI.Voting.Fee
@@ -42,8 +41,6 @@ library
                      , attoparsec
                      , base16-bytestring
                      , resourcet
-                     , esqueleto
-                     , cardano-db
                      , time
                      , binary
                      , binary-strict
@@ -51,8 +48,6 @@ library
                      , bytestring
                      , cardano-api
                      , cardano-binary
-                     , cardano-db
-                     , persistent-postgresql
                      , monad-logger
                      , monoidal-containers
                      , lens-aeson
@@ -86,6 +81,7 @@ library
 
 executable voting-tools
   main-is:             Main.hs
+  other-modules:       Cardano.CLI.Query
   build-depends:       base
                      , aeson
                      , aeson-pretty


### PR DESCRIPTION
- The musl/static build was failing because the psql library fails to
  compile under musl.
- The psql libraries are used by the genesis and rewards commands, but
  not the registration command.
- Therefore we've split the registration command off into it's own
  separate binary to allow it to be compiled statically using musl.