### PR TITLE
Optionally generate MIR certificates when calculating rewards

### DIFF
--- a/src/Cardano/CLI/Fetching.hs
+++ b/src/Cardano/CLI/Fetching.hs
@@ -100,13 +100,15 @@ instance FromJSON Fund where
 
 jsonParserOptions = Aeson.defaultOptions { Aeson.fieldLabelModifier = (fmap toLower) . (drop 2)
                                          }
-
 chunkFund :: Int -> Fund -> [Fund]
-chunkFund x f
-  | x <= 0            = []
-chunkFund x (Fund []) = []
-chunkFund x (Fund fs) =
+chunkFund c (Fund fs) = Fund <$> chunk c fs
+
+chunk :: Int -> [a] -> [[a]]
+chunk c xs
+  | c <= 0 = []
+chunk c [] = []
+chunk c xs =
   let
-    (chunk, rest) = splitAt x fs
+    (ch, rest) = splitAt c xs
   in
-    [Fund chunk] <> chunkFund x (Fund rest)
+    [ch] <> chunk c rest

--- a/src/Cardano/CLI/Query.hs
+++ b/src/Cardano/CLI/Query.hs
@@ -142,7 +142,7 @@ queryVoteRegistrationInfo mSlotNo  = do
                                  else acc
            ) mempty regos
 
-  liftIO $ hPutStr stderr $ "\nKeys eligible: " <> show (length xs)
+  liftIO $ hPutStrLn stderr $ "\nKeys eligible: " <> show (length xs)
 
   let
     xs' = zip [1..] (M.toList xs)

--- a/src/Config/Rewards.hs
+++ b/src/Config/Rewards.hs
@@ -43,14 +43,16 @@ data Config = Config
     -- ^ Total rewards to distribute between voters
     , cfgOutFile           :: FilePath
     -- ^ File to write rewards info to
+    , cfgOutMIRDir         :: Maybe FilePath
+    -- ^ Folder to write MIR certificates to
     }
   deriving (Eq, Show)
 
 mkConfig
   :: Opts
   -> Config
-mkConfig (Opts networkId dbName dbUser dbHost mSlotNo threshold totalRewards outfile) = do
-  Config networkId threshold (DatabaseConfig dbName dbUser dbHost) mSlotNo totalRewards outfile
+mkConfig (Opts networkId dbName dbUser dbHost mSlotNo threshold totalRewards outfile mirDir) = do
+  Config networkId threshold (DatabaseConfig dbName dbUser dbHost) mSlotNo totalRewards outfile mirDir
 
 data Opts = Opts
     { optNetworkId      :: NetworkId
@@ -61,6 +63,7 @@ data Opts = Opts
     , optThreshold      :: Threshold
     , optTotalRewards   :: Lovelace
     , optOutFile        :: FilePath
+    , optOutMIRDir      :: Maybe FilePath
     }
     deriving (Eq, Show)
 
@@ -74,6 +77,7 @@ parseOpts = Opts
   <*> fmap fromIntegral (option auto (long "threshold" <> metavar "INT64" <> showDefault <> value defaultThreshold <> help "Minimum threshold of funds required to vote (Lovelace)"))
   <*> fmap fromIntegral (option auto (long "total-rewards" <> metavar "INT64" <> help "Total rewards to distribute between voters"))
   <*> strOption (long "out-file" <> metavar "FILE" <> help "File to output the signed transaction to")
+  <*> optional (strOption (long "mir-dir" <> metavar "FOLDER" <> help "Folder to output MIR certificates to"))
 
 opts =
   info

--- a/voting-tools.cabal
+++ b/voting-tools.cabal
@@ -85,43 +85,44 @@ executable voting-tools
   build-depends:       base
                      , aeson
                      , aeson-pretty
-                     , unordered-containers
                      , attoparsec
                      , base16-bytestring
                      , bech32
-                     , bytestring
-                     , conduit
-                     , lens-aeson
                      , binary
+                     , bytestring
                      , cardano-api
                      , cardano-binary
                      , cardano-cli
-                     , cardano-crypto-class
-                     , cardano-ledger
                      , cardano-crypto
-                     , containers
-                     , esqueleto
-                     , time
+                     , cardano-crypto-class
                      , cardano-db
-                     , resourcet
+                     , cardano-ledger
+                     , cardano-ledger-shelley-ma
+                     , conduit
+                     , containers
+                     , directory
+                     , esqueleto
+                     , lens
+                     , lens-aeson
                      , monad-logger
                      , monoidal-containers
-                     , lens
                      , mtl
                      , nothunks
-                     , cardano-ledger-shelley-ma
-                     , persistent-postgresql
                      , optparse-applicative
                      , ouroboros-consensus
                      , ouroboros-consensus-cardano
                      , ouroboros-consensus-shelley
                      , ouroboros-network
                      , ouroboros-network-framework
+                     , persistent-postgresql
+                     , resourcet
                      , safe-exceptions
-                     , shelley-spec-ledger
                      , scientific
+                     , shelley-spec-ledger
                      , text
+                     , time
                      , transformers-except
+                     , unordered-containers
                      , voting-tools
 
   hs-source-dirs:      src/


### PR DESCRIPTION
- Add an optional flag "--mir-dir" that allows the user to specify a
  directory to output the MIR certificates. The rewards are split
  into chunks of 200 and each chunk output is output to a separate MIR
  certificate.