### PR TITLE
Expose voter registration tarball in hydra-build-products

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,13 +5,6 @@ steps:
     agents:
       system: x86_64-linux
 
-    command:
-      - 'nix-build -A voterRegistrationTarball'
-    artifact_paths:
-      - "result/voter-registration.tar.gz"
-    agents:
-      system: x86_64-linux
-
   - label: 'style'
     command: nix-shell --pure --run 'find . -type f -name "*.hs" -not -path ".git" -not -path "*.stack-work*" -print0 | xargs -0 stylish-haskell -i && git diff --exit-code'
     agents:

--- a/README.md
+++ b/README.md
@@ -47,3 +47,19 @@ make dev target=exe:voter-registration
 # Launch a ghci session for the given target
 make repl target=lib:voting-tools
 ```
+
+## Distribution
+
+A static binary for the "voter-registration" executable is provided.
+Due to limitations in our cross-compilation infrastructure
+(specifically, static binaries cannot be produced of postgresql
+librarys), a static binary cannot be provided for the "voting-tools"
+executable.
+
+The latest static binary can be found
+[here](https://hydra.iohk.io/job/Cardano/voting-tools/native.voterRegistrationTarball.x86_64-linux/latest/download/1/voter-registration.tar.gz),
+or built with Nix using:
+
+```
+nix-build -A voterRegistrationTarball
+```

--- a/default.nix
+++ b/default.nix
@@ -25,8 +25,9 @@ let
     (selectProjectPackages pkgs.pkgsCross.musl64.votingToolsHaskellPackages);
   voterRegistrationTarball = pkgs.runCommandNoCC "voter-registration-tarball" { buildInputs = [ pkgs.gnutar gzip ]; } ''
     cp ${haskellPackagesMusl64.voter-registration.components.exes.voter-registration}/bin/voter-registration ./
-    mkdir -p $out
+    mkdir -p $out/nix-support
     tar -czvf $out/voter-registration.tar.gz voter-registration
+    echo "file binary-dist $out/voter-registration.tar.gz" > $out/nix-support/hydra-build-products
   '';
 
   self = {


### PR DESCRIPTION
- Record static voter-registration build in hydra-build-products so
  it's exposed for download.
- Remove static voter-registration build from Buildkite.