### PR TITLE
Print the reason why vote registrations are rejected 

### DIFF
--- a/.buildkite/check-stylish.sh
+++ b/.buildkite/check-stylish.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+stylish-haskell -i `git ls-files -- '*.hs'`
+
+git diff --exit-code

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ steps:
     agents:
       system: x86_64-linux
 
-  - label: 'style'
-    command: nix-shell --pure --run 'find . -type f -name "*.hs" -not -path ".git" -not -path "*.stack-work*" -print0 | xargs -0 stylish-haskell -i && git diff --exit-code'
+  - label: 'Check Stylish Haskell'
+    command: 'nix-shell --run .buildkite/check-stylish.sh'
     agents:
       system: x86_64-linux

--- a/src/Cardano/CLI/Query.hs
+++ b/src/Cardano/CLI/Query.hs
@@ -14,7 +14,7 @@ import           Control.Monad.Reader (MonadReader, ask, asks, runReaderT)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BC
 import           Data.Either (partitionEithers)
-import           Data.Foldable (for_, forM_)
+import           Data.Foldable (forM_, for_)
 import           Data.Function ((&))
 import           Data.List (foldl', partition)
 import           Data.Monoid (Sum (Sum), getSum)

--- a/src/Cardano/CLI/Query.hs
+++ b/src/Cardano/CLI/Query.hs
@@ -221,12 +221,12 @@ queryVotingProportion nw mSlotNo (Api.Lovelace threshold) = do
   --                   └── But the voting power did not exceed the threshold.
   info <-  queryVoteRegistrationInfo nw mSlotNo
 
-  for_ (causeSumAmounts info) $ \(votepub, amt) -> do
-      if amt < fromIntegral threshold
-      then
-          liftIO $ hPutStr stderr $ notEnoughVotingPowerError votepub
-      else
-          pure ()
+  let
+      didntMeetThreshold =
+          filter ((< fromIntegral threshold) . snd) $ causeSumAmounts info
+  liftIO $
+      mapM_ (hPutStrLn stderr . notEnoughVotingPowerError . fst)
+            didntMeetThreshold
 
   let
     proportions :: [((Api.StakeAddress, Api.Hash Api.StakeKey), Double)]

--- a/src/Cardano/CLI/Query.hs
+++ b/src/Cardano/CLI/Query.hs
@@ -14,6 +14,7 @@ import           Control.Monad.Reader (MonadReader, ask, asks, runReaderT)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BC
 import           Data.Function ((&))
+import           Data.Foldable (for_)
 import           Data.List (foldl')
 import           Data.Monoid (Sum (Sum), getSum)
 import           Data.Ratio (Ratio, denominator, numerator)
@@ -23,7 +24,8 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TL
 import           Data.Traversable (for, forM)
 import           Data.Word (Word64)
-import           Database.Esqueleto (BackendCompatible, Single (Single))
+import           Data.Either (partitionEithers)
+import           Database.Esqueleto (BackendCompatible, Single (Single), fromSqlKey)
 import           Database.Persist.Postgresql (Entity, IsolationLevel (Serializable), SqlBackend,
                      SqlPersistT, rawExecute, rawSql, runSqlConnWithIsolation)
 import           System.IO (hPutStr, hPutStrLn, stderr)
@@ -40,7 +42,7 @@ import           Cardano.CLI.Fetching (Fund, Threshold, VotingFunds (VotingFunds
 import           Cardano.CLI.Voting.Metadata (AsMetadataParsingError (..), MetadataParsingError,
                      Vote, metadataMetaKey, parseMetadataFromJson, signatureMetaKey,
                      voteFromTxMetadata, voteRegistrationPublicKey, voteRegistrationRewardsAddress,
-                     voteRegistrationVerificationKey, withMetaKey)
+                     voteRegistrationVerificationKey, withMetaKey, prettyPrintMetadataParsingError)
 import           Cardano.CLI.Voting.Signing (AsType (AsVoteVerificationKeyHash),
                      VoteVerificationKeyHash, getStakeHash, getVoteVerificationKeyHash)
 import           Contribution (Contributions, causeSumAmounts, contribute, filterAmounts,
@@ -55,27 +57,48 @@ import qualified Data.Map.Strict as M
 import qualified Cardano.API.Jormungandr as Jormungandr
 
 data MetadataRetrievalError
-  = MetadataFailedToRetrieveMetadataField
-  | MetadataFailedToRetrieveSignatureField
-  | MetadataFailedToDecodeMetadataField !String
-  | MetadataFailedToDecodeSignatureField !String
-  | MetadataFailedToDecodeTxMetadata Aeson.Object !Api.TxMetadataJsonError
+  = MetadataFailedToRetrieveMetadataField !TxId
+  | MetadataFailedToRetrieveSignatureField !TxId
+  | MetadataFailedToDecodeMetadataField !TxId !Text
+  | MetadataFailedToDecodeSignatureField !TxId !Text
+  | MetadataFailedToDecodeTxMetadata !TxId !Api.TxMetadataJsonError
+  | MetadataFailedToParseVoteRegistration !TxId !MetadataParsingError
   deriving (Eq, Show)
 
 makeClassyPrisms ''MetadataRetrievalError
 
-data MetadataError
-  = MetadataErrorRetrieval !MetadataRetrievalError
-  | MetadataErrorParsing !MetadataParsingError
-  deriving (Eq, Show)
+prettyPrintMetadataRetrievalError :: MetadataRetrievalError -> Text
+prettyPrintMetadataRetrievalError (MetadataFailedToRetrieveMetadataField txId) =
+  "There was no metadata JSON (key \"61284\") value associated with the tx \""
+  <> prettyPrintTxId txId <> "\""
+prettyPrintMetadataRetrievalError (MetadataFailedToRetrieveSignatureField txId) =
+  "There was no signature JSON (key \"61285\") value associated with the tx \""
+  <> prettyPrintTxId txId <> "\""
+prettyPrintMetadataRetrievalError (MetadataFailedToDecodeMetadataField txId err) =
+  "Couldn't decode JSON value at metadata key \"61284\" for transaction \"" 
+  <> prettyPrintTxId txId <> "\". Error was: \"" <> err <> "\""
+prettyPrintMetadataRetrievalError (MetadataFailedToDecodeSignatureField txId err) =
+  "Couldn't decode JSON value at signature key \"61285\" for transaction \"" 
+  <> prettyPrintTxId txId <> "\". Error was: \"" <> err <> "\""
+prettyPrintMetadataRetrievalError (MetadataFailedToDecodeTxMetadata txId err) =
+  "The metadata entry associated with transaction \"" <> prettyPrintTxId txId
+  <> "\" was not valid TxMetadata. Parsing failed with error: \""
+  <> T.pack (Api.displayError err) <> "\""
+prettyPrintMetadataRetrievalError (MetadataFailedToParseVoteRegistration txId err) =
+  "The TxMetadata associated with transaction \"" <> prettyPrintTxId txId
+  <> "\" was not a valid vote registration. Parsing failed with error: \""
+  <> prettyPrintMetadataParsingError err <> "\""
 
-makeClassyPrisms ''MetadataError
+retrievalErrorTxId :: MetadataRetrievalError -> TxId
+retrievalErrorTxId (MetadataFailedToRetrieveMetadataField txId)   = txId
+retrievalErrorTxId (MetadataFailedToRetrieveSignatureField txId)  = txId
+retrievalErrorTxId (MetadataFailedToDecodeMetadataField txId _)   = txId
+retrievalErrorTxId (MetadataFailedToDecodeSignatureField txId _)  = txId
+retrievalErrorTxId (MetadataFailedToDecodeTxMetadata txId _)      = txId
+retrievalErrorTxId (MetadataFailedToParseVoteRegistration txId _) = txId
 
-instance AsMetadataRetrievalError MetadataError where
-  _MetadataRetrievalError = _MetadataErrorRetrieval
-
-instance AsMetadataParsingError MetadataError where
-  _MetadataParsingError = _MetadataErrorParsing
+prettyPrintTxId :: TxId -> Text
+prettyPrintTxId = T.pack . show . fromSqlKey 
 
 queryStake
   :: ( MonadIO m
@@ -103,9 +126,6 @@ queryVoteRegistrationInfo
   :: ( MonadIO m
      , MonadReader backend m
      , BackendCompatible SqlBackend backend
-     , MonadError e m
-     , AsMetadataParsingError e
-     , AsMetadataRetrievalError e
      )
   => Api.NetworkId
   -> Maybe SlotNo
@@ -113,7 +133,19 @@ queryVoteRegistrationInfo
 queryVoteRegistrationInfo nw mSlotNo  = do
   regos <- queryVoteRegistration nw mSlotNo
 
-  liftIO $ hPutStr stderr $ "\nRaw DB query rows returned: " <> show (length regos)
+  liftIO $ hPutStr stderr $ "\nFound " <> show (length regos) <> " vote registrations. Of which, "
+
+  let
+      (badRegos, goodRegos) = partitionEithers regos
+
+  liftIO $ hPutStr stderr $ "\n\t" <> show (length goodRegos) <> " were good vote registrations."
+  liftIO $ hPutStr stderr $ "\n\t" <> show (length badRegos) <> " were bad vote registrations."
+
+  liftIO $ hPutStr stderr $ "\n Failed transactions:"
+  for_ badRegos $ \err ->
+    liftIO $ hPutStr stderr $ T.unpack
+      $ "\n - tx: '" <> prettyPrintTxId (retrievalErrorTxId err) <> "',"
+      <> " reason: '" <> prettyPrintMetadataRetrievalError err <> "'"
 
   let
     -- Each stake key has one public voting key it can stake to
@@ -142,7 +174,7 @@ queryVoteRegistrationInfo nw mSlotNo  = do
                  Just (t, _)  -> if txid >= t
                                  then M.insert verKeyHash (txid, (votePub, rewardsAddr)) acc
                                  else acc
-           ) mempty regos
+           ) mempty goodRegos
 
   liftIO $ hPutStrLn stderr $ "\nKeys eligible: " <> show (length xs)
 
@@ -170,9 +202,6 @@ queryVotingProportion
   :: ( MonadIO m
      , MonadReader backend m
      , BackendCompatible SqlBackend backend
-     , MonadError e m
-     , AsMetadataParsingError e
-     , AsMetadataRetrievalError e
      )
   => Api.NetworkId
   -> Maybe SlotNo
@@ -190,12 +219,19 @@ queryVotingProportion nw mSlotNo (Api.Lovelace threshold) = do
   --           └── The metadata was valid cardano-api TxMetadata
   --               └── The metadata constituted a valid vote
   --                   └── But the voting power did not exceed the threshold.
-  info <- filterAmounts (> threshold) <$> queryVoteRegistrationInfo nw mSlotNo
+  info <-  queryVoteRegistrationInfo nw mSlotNo
+
+  for_ (causeSumAmounts info) $ \(votepub, amt) -> do
+      if amt < fromIntegral threshold
+      then
+          liftIO $ hPutStr stderr $ notEnoughVotingPowerError votepub
+      else
+          pure ()
 
   let
     proportions :: [((Api.StakeAddress, Api.Hash Api.StakeKey), Double)]
     proportions =
-      proportionalize info
+      proportionalize (filterAmounts (> threshold) info)
       & foldMap snd
       & fmap (fmap convertRatio)
 
@@ -208,9 +244,6 @@ queryVotingFunds
   :: ( MonadIO m
      , MonadReader backend m
      , BackendCompatible SqlBackend backend
-     , MonadError e m
-     , AsMetadataParsingError e
-     , AsMetadataRetrievalError e
      )
   => Api.NetworkId
   -> Maybe SlotNo
@@ -219,29 +252,27 @@ queryVotingFunds
 queryVotingFunds nw mSlotNo (Api.Lovelace threshold) = do
   info <- queryVoteRegistrationInfo nw mSlotNo
 
-  let info' = filterAmounts (> threshold) info
+  funds <- fmap mconcat . forM (causeSumAmounts info) $ \(votepub, amt) -> do
+      if amt < fromIntegral threshold
+      then do
+          liftIO $ hPutStr stderr $ notEnoughVotingPowerError votepub
+          pure []
+      else do
+        pure [ ( Jormungandr.addressFromVotingKeyPublic nw votepub
+               , Api.Lovelace $ numerator amt
+               )
+             ]
 
-  pure
-    $ VotingFunds
-    $ M.fromList
-    $ fmap (\(votepub, amt) ->
-              ( Jormungandr.addressFromVotingKeyPublic nw votepub
-              , Api.Lovelace $ numerator amt
-              )
-           )
-    $ causeSumAmounts info'
+  pure $ VotingFunds $ M.fromList funds
 
 queryVoteRegistration
   :: ( MonadIO m
-     , MonadError e m
-     , AsMetadataParsingError e
-     , AsMetadataRetrievalError e
      , MonadReader backend m
      , BackendCompatible SqlBackend backend
      )
   => Api.NetworkId
   -> Maybe SlotNo
-  -> m [(TxId, Vote)]
+  -> m [Either MetadataRetrievalError (TxId, Vote)]
 queryVoteRegistration nw mSlotNo =
   let
     -- Join the transaction information with the metadata information for that
@@ -256,7 +287,10 @@ queryVoteRegistration nw mSlotNo =
         Nothing   -> (sqlBase <> " ORDER BY metadata -> '4' ASC;")
     r <- ask
     (results :: [(Single ByteString, Single TxId, Single (Maybe Text), Single (Maybe Text))]) <- (flip runReaderT) r $ rawSql sql []
-    fmap mconcat $ forM results $ \(Single txHash, Single txId, Single mMetadata, Single mSignature) -> do
+    sequence $ fmap runExceptT $ (flip fmap) results $ \(Single txHash, Single txId, Single mMetadata, Single mSignature) -> do
+      let
+          handleEither f = 
+              either (throwError . f) pure
       -- DECISION #01:
       --   When querying the transaction/metadata/signature information, the
       --   given row did not have a metadata entry under the key '61284' (i.e.
@@ -267,7 +301,11 @@ queryVoteRegistration nw mSlotNo =
       --
       -- FIXME: Isn't this prevented by the query? Wouldn't it always be Just?
       -- Answer is yes - there is no need to make this a "Maybe".
-      metadata  <- maybe (throwError $ _MetadataFailedToRetrieveMetadataField # ()) pure mMetadata
+      metadata  <-
+          maybe
+          (throwError $ _MetadataFailedToRetrieveMetadataField # txId)
+          pure
+          mMetadata
       -- DECISION #02:
       --   When querying the transaction/metadata/signature information, the
       --   given row did not have a metadata signature entry under the key
@@ -278,8 +316,11 @@ queryVoteRegistration nw mSlotNo =
       --
       -- FIXME: Isn't this prevented by the query? Wouldn't it always be Just?
       -- Answer is yes - there is no need to make this a "Maybe".
-      signature <- maybe (throwError $ _MetadataFailedToRetrieveSignatureField # ()) pure mSignature
-
+      signature <-
+          maybe
+          (throwError $ _MetadataFailedToRetrieveSignatureField # txId)
+          pure
+          mSignature
 
       -- DECISION #03:
       --   We found an entry with the right keys but failed to parse the voting
@@ -292,7 +333,9 @@ queryVoteRegistration nw mSlotNo =
       -- This is programmer error - the database should only accept JSON values
       -- into the 'json' column, and even if it doesn't, the tool that submits
       -- the data should only submit valid json. This isn't the voter's fault.
-      metadataObj <- either (throwError . (_MetadataFailedToDecodeMetadataField #)) pure $ Aeson.eitherDecode' $ TL.encodeUtf8 $ TL.fromStrict $ metadata
+      metadataObj <-
+          handleEither (\e -> _MetadataFailedToDecodeMetadataField # (txId, T.pack e))
+          $ Aeson.eitherDecode' $ TL.encodeUtf8 $ TL.fromStrict $ metadata
       -- DECISION #04:
       --   We found an entry with the right keys but failed to parse the signature
       --   metadata because it wasn't a JSON value.
@@ -304,7 +347,9 @@ queryVoteRegistration nw mSlotNo =
       -- This is programmer error - the database should only accept JSON values
       -- into the 'json' column, and even if it doesn't, the tool that submits
       -- the data should only submit valid json. This isn't the voter's fault.
-      signatureObj <- either (throwError . (_MetadataFailedToDecodeSignatureField #)) pure $ Aeson.eitherDecode' $ TL.encodeUtf8 $ TL.fromStrict $ signature
+      signatureObj <-
+          handleEither (\e -> _MetadataFailedToDecodeSignatureField # (txId, T.pack e))
+          $ Aeson.eitherDecode' $ TL.encodeUtf8 $ TL.fromStrict $ signature
 
       let
         metaObj :: Aeson.Object
@@ -327,7 +372,8 @@ queryVoteRegistration nw mSlotNo =
       -- TxMetadata, but if it doesn't, the user may have submitted some
       -- metadata that parses as JSON but not TxMetadata (see cardano-api for
       -- more information on how TxMetadata is a subset of JSON).
-      meta <- either (\err -> throwError $ (_MetadataFailedToDecodeTxMetadata # (metaObj, err))) pure $ parseMetadataFromJson (Aeson.Object metaObj)
+      meta <- handleEither (\e -> _MetadataFailedToDecodeTxMetadata # (txId, e))
+          $ parseMetadataFromJson (Aeson.Object metaObj)
       -- DECISION #06:
       --   We found the TxMetadata, but we were unable to parse a vote from it.
       --
@@ -342,7 +388,26 @@ queryVoteRegistration nw mSlotNo =
       -- submitted a malformed vote.
 
       -- We now ignore any Metadata that fails to decode (generally will be due to entries missing the new "3" metadata field)
-      either (const $ pure []) (\v -> pure [v]) $ fmap (txId,) $ voteFromTxMetadata meta
+      rego <-
+          handleEither (\e -> _MetadataFailedToParseVoteRegistration # (txId, e))
+          $ voteFromTxMetadata meta
+  
+      pure $ (txId, rego)
 
 runQuery :: (MonadIO m) => SqlBackend -> SqlPersistT IO a -> m a
 runQuery backend query = liftIO $ runSqlConnWithIsolation query backend Serializable
+
+notEnoughVotingPowerError :: VotingKeyPublic -> String
+notEnoughVotingPowerError votepub =
+    -- We choose to print the data in hexadecimal because that is the
+    -- format it is stored in the database. This makes it easier for the
+    -- user of the tool to trace the database entry that was rejected. For
+    -- example with a query like:
+    --
+    -- > SELECT * FROM tx_metadata WHERE key = '61284' AND json->'1' = '"0xde3179910ca76d8a8a391e89e8d4057fd0388e7696c1d6f0c3d6545bc16a0c64"';
+    --
+    -- the user can see the metadata that was associated with each transaction
+    -- that tried to register to vote with this public key.
+    "\nRejecting 0x"
+      <> BC.unpack (Api.serialiseToRawBytesHex votepub)
+      <> ", not enough voting power."

--- a/src/Cardano/CLI/Voting/Metadata.hs
+++ b/src/Cardano/CLI/Voting/Metadata.hs
@@ -294,17 +294,13 @@ voteFromTxMetadata meta = do
             (k1, k2) = componentPath comp
         in
             case M.lookup k1 map1 of
-                Nothing ->
-                    throwError (_MetadataMissing # comp)
                 Just (TxMetaMap map2) ->
                     case find (\(k, v) -> k == TxMetaNumber k2) map2 of
-                        Nothing ->
-                            throwError (_MetadataMissing # comp)
                         Just (_, v) ->
                             pure v
-                Just other ->
-                    throwError (_MetadataMissing # comp)
-
+                        Nothing ->
+                            throwError (_MetadataMissing # comp)
+                _ -> throwError (_MetadataMissing # comp)
 
     asBytes :: VoteRegistrationComponent -> TxMetadataValue -> Either MetadataParsingError ByteString
     asBytes _    (TxMetaBytes bs) = pure bs

--- a/src/Cardano/CLI/Voting/Metadata.hs
+++ b/src/Cardano/CLI/Voting/Metadata.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 -- | A vote in Voltaire is encoded as transaction metadata. We
@@ -56,7 +56,7 @@ import           Data.ByteString (ByteString)
 import qualified Data.HashMap.Strict as HM
 import           Data.List (find)
 import qualified Data.Map.Strict as M
-import Data.Text (Text)
+import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Word (Word64)
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto (StandardCrypto)
@@ -304,7 +304,7 @@ voteFromTxMetadata meta = do
                             pure v
                 Just other ->
                     throwError (_MetadataMissing # comp)
-                
+
 
     asBytes :: VoteRegistrationComponent -> TxMetadataValue -> Either MetadataParsingError ByteString
     asBytes _    (TxMetaBytes bs) = pure bs

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -35,7 +35,7 @@ import           System.Directory (createDirectoryIfMissing)
 
 import           Cardano.API.Extended (readEnvSocketPath)
 import           Cardano.CLI.Fetching (Fund, chunk, chunkFund, fundFromVotingFunds, scaleFund)
-import           Cardano.CLI.Query (MetadataError)
+import           Cardano.CLI.Query (MetadataRetrievalError)
 import qualified Cardano.CLI.Query as Query
 import           Cardano.CLI.Voting (createVoteRegistration, encodeVoteRegistration, prettyTx,
                      signTx)
@@ -107,15 +107,15 @@ main = do
 toJSON :: Aeson.ToJSON a => Aeson.NumberFormat -> a -> BLC.ByteString
 toJSON numFormat = Aeson.encodePretty' (Aeson.defConfig { Aeson.confCompare = Aeson.compare, Aeson.confNumFormat = numFormat })
 
-runQuery :: DatabaseConfig -> ExceptT MetadataError (SqlPersistT IO) a -> IO a
+runQuery :: DatabaseConfig -> ExceptT MetadataRetrievalError (SqlPersistT IO) a -> IO a
 runQuery dbConfig q = runNoLoggingT $ do
   logInfoN $ T.pack $ "Connecting to database at " <> _dbHost dbConfig
   withPostgresqlConn (pgConnectionString dbConfig) $ \backend -> do
     result <- Query.runQuery backend $ runExceptT $ q
 
     case result of
-      Left (err :: MetadataError) -> fail $ show err
-      Right x                     -> pure x
+      Left (err :: MetadataRetrievalError) -> fail $ show err
+      Right x                              -> pure x
 
 
 pgConnectionString :: DatabaseConfig -> ConnectionString


### PR DESCRIPTION
[ADP-991](https://jira.iohk.io/browse/ADP-991)
[ADP-984](https://jira.iohk.io/browse/ADP-984)

- Modify the `MetadataRetrievalError` to include the transaction id (useful for
  debugging) and the `MetadataParsingError` as an error node, the previous
  grouping of them under a larger error type (`MetadataError`) was unnecessary.
- Print how many vote registrations were rejected and how many were good.
- For each rejected vote registration, print why that registration was rejected,
  along with the txid of the registration.
- Print registrations that are rejected for not having enough voting power.
- Document the decisions made by the code better.
- Refactor the "voteFromTxMetadata" function to provide better error messages.
