### PR TITLE
Allow vote registrations to be filtered by a slot interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ interact with the voting capabilities of Catalyst.
 
 The "voter-registration" executable creates transaction metadata in the correct format for submission with a transaction, to register a user to vote.
 
-The "voting-tools" creates a snapshot of the voting power of registrations and outputs it as JSON file.
+The "voting-tools" creates a snapshot of the voting power of registrations and outputs it as JSON file. The "--lower-bound" and "--upper-bound" arguments can be used to restrict the snapshot to a particular fund (using the starting and ending slots of the fund).
 
 ## Obtaining
 
@@ -29,7 +29,7 @@ nix-build -A voterRegistrationTarball
 nix-build -A voter-registration -o voter-registration
 nix-build -A voting-tools -o voting-tools
 
-./voting-tools/bin/voting-tools --mainnet --db-user cardano-node --out-file snapshot.json
+./voting-tools/bin/voting-tools --mainnet --db-user cardano-node --out-file snapshot.json --lower-bound 33300 --upper-bound 40000
 ```
 
 ## Registering to vote

--- a/src/Config/Snapshot.hs
+++ b/src/Config/Snapshot.hs
@@ -73,18 +73,18 @@ pSlotInterval = SlotInterval
   <$> optional (option (SlotNo <$> auto)
           ( long "lower-slot-no"
           <> metavar "WORD64"
-          <> help "lower bound of slot number interval (inclusive). Registrations made on or after this slot number are included in the snapshot. Leave blank for -INF."
+          <> help "Lower bound of slot number interval (inclusive). Registrations made on or after this slot number are included in the snapshot (default: -INF)"
           ))
   <*> optional (option (SlotNo <$> auto)
           ( long "upper-slot-no"
           <> metavar "WORD64"
-          <> help "upper bound of slot number interval (inclusive). Registrations made on or before this slot number are included in the snapshot. Leave blank for +INF."
+          <> help "Upper bound of slot number interval (inclusive). Registrations made on or before this slot number are included in the snapshot (default: +INF)"
           ))
 
 opts :: ParserInfo Opts
 opts =
   info
-    ( parseOpts )
+    ( parseOpts <**> helper )
     ( fullDesc
     <> progDesc "Create a voting power snapshot"
     <> header "voting-tools snapshot - tool to grab snapshot of voting power"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -26,9 +26,9 @@ main = do
   case eCfg of
     Left (err :: Snapshot.ConfigError) ->
       fail $ show err
-    Right (Snapshot.Config networkId scale db slotNo outfile) -> do
+    Right (Snapshot.Config networkId scale db slotInterval outfile) -> do
       votingFunds <-
-        runQuery db $ Query.queryVotingFunds networkId slotNo
+        runQuery db $ Query.queryVotingFunds networkId slotInterval
 
       let
         scaled = votingPowerFromRegistrationInfo scale <$> votingFunds


### PR DESCRIPTION
[ADP-1403](https://input-output.atlassian.net/browse/ADP-1403)

- Vote registrations can now be filtered by a lower and upper (inclusive) slot
  bound.
- Using this we can determine the users who registered during a fund.