### PR TITLE
Ensure "required" job is not behind a system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,60 +42,66 @@
         (import ./nix/pkgs.nix)
       ];
 
-    in (eachSystem supportedSystems (system:
-      let
-        pkgs = import nixpkgs {
-          inherit system overlays;
-          inherit (haskellNix) config;
-        };
-
-        flake = pkgs.votingToolsHaskellProject.flake {
-          crossPlatforms = p: with p; [
-            musl64
-          ];
-        };
-        packages = collectExes flake.packages // {
-          voterRegistrationTarball = pkgs.runCommandNoCC "voter-registration-tarball" { buildInputs = [ pkgs.gnutar pkgs.gzip ]; } ''
-            cp ${flake.packages."x86_64-unknown-linux-musl:voter-registration:exe:voter-registration"}/bin/voter-registration ./
-            mkdir -p $out/nix-support
-            tar -czvf $out/voter-registration.tar.gz voter-registration
-            echo "file binary-dist $out/voter-registration.tar.gz" > $out/nix-support/hydra-build-products
-          '';
-        };
-
-      in recursiveUpdate flake {
-
-        inherit packages;
-
-        legacyPackages = pkgs;
-
-        devShells.stylish = pkgs.mkShell { packages = with pkgs; [ stylish-haskell git ]; };
-
-        # Built by `nix build .`
-        defaultPackage = flake.packages."voting-tools:exe:voting-tools";
-
-        # Run by `nix run .`
-        defaultApp = flake.apps."voting-tools:exe:voting-tools";
-
-        inherit (flake) apps;
-
-        hydraJobs =
+    in
+      recursiveUpdate
+        # System-dependent jobs
+        (eachSystem supportedSystems (system:
           let
-            jobs =
-              lib.recursiveUpdate self.packages.${system} self.checks.${system} // {
-                nixosTests = import ./nix/nixos/tests/default.nix {
-                  inherit pkgs system inputs;
-                };
-              };
-          in
-            jobs // {
-              required = with self.legacyPackages.${lib.head supportedSystems}; releaseTools.aggregate {
-                name = "github-required";
-                meta.description = "All jobs required to pass CI";
-                constituents = lib.collect lib.isDerivation jobs ++ lib.singleton
-                  (writeText "forceNewEval" self.rev or "dirty");
-              };
+            pkgs = import nixpkgs {
+              inherit system overlays;
+              inherit (haskellNix) config;
             };
-      }
-    ));
+
+            flake = pkgs.votingToolsHaskellProject.flake {
+              crossPlatforms = p: with p; [
+                musl64
+              ];
+            };
+            packages = collectExes flake.packages // {
+              voterRegistrationTarball = pkgs.runCommandNoCC "voter-registration-tarball" { buildInputs = [ pkgs.gnutar pkgs.gzip ]; } ''
+                cp ${flake.packages."x86_64-unknown-linux-musl:voter-registration:exe:voter-registration"}/bin/voter-registration ./
+                mkdir -p $out/nix-support
+                tar -czvf $out/voter-registration.tar.gz voter-registration
+                echo "file binary-dist $out/voter-registration.tar.gz" > $out/nix-support/hydra-build-products
+              '';
+            };
+
+          in recursiveUpdate flake {
+
+            inherit packages;
+
+            legacyPackages = pkgs;
+
+            devShells.stylish = pkgs.mkShell { packages = with pkgs; [ stylish-haskell git ]; };
+
+            # Built by `nix build .`
+            defaultPackage = flake.packages."voting-tools:exe:voting-tools";
+
+            # Run by `nix run .`
+            defaultApp = flake.apps."voting-tools:exe:voting-tools";
+
+            inherit (flake) apps;
+
+            hydraJobs =
+              let
+                jobs =
+                  lib.recursiveUpdate self.packages.${system} self.checks.${system} // {
+                    nixosTests = import ./nix/nixos/tests/default.nix {
+                      inherit pkgs system inputs;
+                    };
+                  };
+              in
+                jobs;
+          }
+        )
+      )
+    # Non-system-dependent jobs
+    {
+      hydraJobs.required = with self.legacyPackages.${lib.head supportedSystems}; releaseTools.aggregate {
+        name = "github-required";
+        meta.description = "All jobs required to pass CI";
+        constituents = lib.collect lib.isDerivation jobs ++ lib.singleton
+          (writeText "forceNewEval" self.rev or "dirty");
+      };
+    };
 }


### PR DESCRIPTION
- hydraJobs.required.x86_64-linux -> hydraJobs.required
  - The required derivation must be at the `hydraJobs.required` location, it
    cannot be under a system (e.g. x86_64-linux).