### PR TITLE
Fix reward address

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -24,6 +24,7 @@ export CARDANO_NODE_SOCKET_PATH="/run/cardano-node/node.socket"
 
 ## Generate Stake Address
 
+TODO: This is outdated since a regular shelley address is now used for the rewards
 Generate a stake address from a stake key:
 
 ``` shell

--- a/cabal.project
+++ b/cabal.project
@@ -194,6 +194,7 @@ constraints:
   , network >= 3.1.1.0
   -- needed until we update past cardano-ledger@43f7c7318e38c501c2d2a2c680251c7c1f78d0fd
   , hashable < 1.3.4.0
+  , base16-bytestring == 1.0.1.0
 
 package comonad
   flags: -test-doctests

--- a/registration/app/Main.hs
+++ b/registration/app/Main.hs
@@ -13,7 +13,7 @@ import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Options.Applicative as Opt
 import           Ouroboros.Network.Block (unSlotNo)
 
-import           Cardano.Catalyst.Registration (RewardsAddress (..), createVoteRegistration,
+import           Cardano.Catalyst.Registration (VoteRewardsAddress (..), createVoteRegistration,
                    voteToTxMetadata)
 import qualified Config.Registration as Register
 
@@ -28,7 +28,7 @@ main = do
       -- Create a vote registration, encoding our registration
       -- as transaction metadata.
       let
-        vote = createVoteRegistration voteSign votePub (RewardsAddress rewardsAddr) (toInteger $ unSlotNo slotNo)
+        vote = createVoteRegistration voteSign votePub (Address rewardsAddr) (toInteger $ unSlotNo slotNo)
         meta = voteToTxMetadata vote
 
       case outFormat of

--- a/registration/src/Config/Registration.hs
+++ b/registration/src/Config/Registration.hs
@@ -50,7 +50,7 @@ import           Cardano.API.Extended (AsBech32DecodeError (_Bech32DecodeError),
                    parseStakeAddress, readerFromAttoParser)
 
 data Config = Config
-    { cfgRewardsAddress  :: StakeAddress
+    { cfgRewardsAddress  :: Api.Address Api.ShelleyAddr
     , cfgStakeSigningKey :: StakeSigningKey
     , cfgDelegations     :: Delegations VotingKeyPublic
     , cfgSlotNo          :: Api.SlotNo

--- a/registration/src/Config/Registration.hs
+++ b/registration/src/Config/Registration.hs
@@ -37,7 +37,7 @@ import           Data.Word (Word32)
 
 import           Options.Applicative
 
-import           Cardano.Api (Bech32DecodeError, StakeAddress)
+import           Cardano.Api (AddressAny (..), Bech32DecodeError, StakeAddress)
 import qualified Cardano.Api as Api
 import           Cardano.CLI.Shelley.Key (InputDecodeError)
 import           Cardano.CLI.Types (SigningKeyFile (..))
@@ -47,7 +47,7 @@ import           Config.Common (versionOption)
 import           Cardano.API.Extended (AsBech32DecodeError (_Bech32DecodeError),
                    AsFileError (_FileIOError, __FileError), AsInputDecodeError (_InputDecodeError),
                    AsType (AsVotingKeyPublic), VotingKeyPublic, deserialiseFromBech32',
-                   parseStakeAddress, readerFromAttoParser)
+                   parseShelleyAddress, readerFromAttoParser)
 
 data Config = Config
     { cfgRewardsAddress  :: Api.Address Api.ShelleyAddr
@@ -100,7 +100,7 @@ mkConfig (Opts rewardsAddr delegations vskf slotNo outFormat) = do
   pure $ Config rewardsAddr stkSign delegations' slotNo outFormat
 
 data Opts = Opts
-    { optRewardsAddress      :: StakeAddress
+    { optRewardsAddress      :: Api.Address Api.ShelleyAddr
     , optVotePublicKeyFile   :: DelegationsCLI
     , optStakeSigningKeyFile :: FilePath
     , optSlotNo              :: Api.SlotNo
@@ -110,7 +110,7 @@ data Opts = Opts
 
 parseOpts :: Parser Opts
 parseOpts = Opts
-  <$> option (readerFromAttoParser parseStakeAddress) (long "rewards-address" <> metavar "STRING" <> help "address associated with rewards (Must be a stake address for MIR Certificate)")
+  <$> option (readerFromAttoParser parseShelleyAddress) (long "rewards-address" <> metavar "STRING" <> help "address associated with rewards (Must be a Shelley Address)")
   <*> pDelegationsCLI
   <*> strOption (long "stake-signing-key-file" <> metavar "FILE" <> help "stake authorizing vote key")
   <*> pSlotNo

--- a/registration/voter-registration.cabal
+++ b/registration/voter-registration.cabal
@@ -28,6 +28,7 @@ library
   exposed-modules: Config.Registration
   build-depends:       base
                      , aeson
+                     , base16-bytestring
                      , bytestring
                      , cardano-api
                      , mtl

--- a/src/Cardano/API/Extended.hs
+++ b/src/Cardano/API/Extended.hs
@@ -19,6 +19,7 @@ module Cardano.API.Extended ( readSigningKeyFileAnyOf
                             , AsInputDecodeError(..)
                             , Extended.readerFromAttoParser
                             , Extended.parseStakeAddress
+                            , Extended.parseShelleyAddress
                             , Extended.pNetworkId
                             , AsBech32DecodeError(..)
                             , AsBech32HumanReadablePartError(..)

--- a/src/Cardano/API/Extended/Raw.hs
+++ b/src/Cardano/API/Extended/Raw.hs
@@ -19,10 +19,17 @@ import           Data.Text (Text)
 import qualified Data.Text.Encoding as T
 import qualified Options.Applicative as Opt
 
-import           Cardano.Api (AddressAny, AsType (AsAddressAny, AsStakeAddress), HasTextEnvelope,
-                   NetworkId (Mainnet, Testnet), NetworkMagic (..), StakeAddress, TextEnvelopeDescr,
-                   deserialiseAddress, serialiseToTextEnvelope)
-import           Cardano.Api.Shelley ()
+import           Cardano.Api (AddressAny, AsType (AsAddressAny, AsShelleyAddress, AsStakeAddress),
+                   HasTextEnvelope, NetworkId (Mainnet, Testnet), NetworkMagic (..), StakeAddress,
+                   TextEnvelopeDescr, deserialiseAddress, serialiseToTextEnvelope)
+import           Cardano.Api.Shelley (Address, ShelleyAddr)
+
+parseShelleyAddress :: Atto.Parser (Address ShelleyAddr)
+parseShelleyAddress = do
+    str <- lexPlausibleAddressString
+    case deserialiseAddress AsShelleyAddress str of
+      Nothing   -> fail "invalid shelley address"
+      Just addr -> pure addr
 
 parseAddressAny :: Atto.Parser AddressAny
 parseAddressAny = do

--- a/src/Cardano/Catalyst/Test/DSL/Gen.hs
+++ b/src/Cardano/Catalyst/Test/DSL/Gen.hs
@@ -84,7 +84,7 @@ import           Cardano.Catalyst.Crypto (StakeSigningKey, StakeVerificationKey,
                    stakeAddressFromKeyHash, stakeAddressFromVerificationKey,
                    stakeVerificationKeyHash)
 import           Cardano.Catalyst.Registration (DelegationWeight, Delegations (..),
-                   RewardsAddress (..), Vote, VotePayload, createVoteRegistration, mkVotePayload)
+                   VoteRewardsAddress (..), Vote, VotePayload, createVoteRegistration, mkVotePayload)
 import           Cardano.Catalyst.Registration.Types.Purpose (Purpose, catalystPurpose, mkPurpose)
 import           Cardano.Catalyst.Test.DSL.Internal.Types (Graph (..), PersistState (..),
                    Registration (..), StakeRegistration (..), Transaction (..), UTxO (..),
@@ -507,7 +507,7 @@ genStakeVerificationKey :: (MonadGen m, MonadIO m) => m StakeVerificationKey
 genStakeVerificationKey =
   getStakeVerificationKey <$> genVoteSigningKey
 
-genRewardsAddress :: (MonadGen m, MonadIO m) => m RewardsAddress
+genRewardsAddress :: (MonadGen m, MonadIO m) => m VoteRewardsAddress
 genRewardsAddress = do
   signingKey <- liftIO $ generateSigningKey AsStakeKey
   let hashStakeKey = verificationKeyHash . getVerificationKey $ signingKey

--- a/src/Cardano/Catalyst/Test/DSL/Internal/Types.hs
+++ b/src/Cardano/Catalyst/Test/DSL/Internal/Types.hs
@@ -100,7 +100,7 @@ module Cardano.Catalyst.Test.DSL.Internal.Types
 import           Cardano.API.Extended (VotingKeyPublic)
 import           Cardano.Catalyst.Crypto (StakeSigningKey, getStakeVerificationKey,
                    stakeAddressFromVerificationKey)
-import           Cardano.Catalyst.Registration (Delegations, RewardsAddress, Vote, VotePayload (..),
+import           Cardano.Catalyst.Registration (Delegations, VoteRewardsAddress, Vote, VotePayload (..),
                    catalystPurpose, createVoteRegistration, voteRegistrationSlot)
 import           Cardano.Db.Extended ()
 import           Data.Kind (Type)
@@ -296,7 +296,7 @@ getStakeAddressId = Db.txOutStakeAddressId . utxoTxOut
 data Registration (state :: PersistState) = Registration
   { registrationDelegations    :: Delegations VotingKeyPublic
   -- ^ Vote power delegations.
-  , registrationRewardsAddress :: RewardsAddress
+  , registrationRewardsAddress :: VoteRewardsAddress
   -- ^ The main-chain address voter rewards should be sent to.
   , registrationSlotNo         :: SlotNo
   -- ^ The nonce used in the registration transaction (usually a slot number).

--- a/src/Cardano/Catalyst/VotePower.hs
+++ b/src/Cardano/Catalyst/VotePower.hs
@@ -20,7 +20,7 @@ module Cardano.Catalyst.VotePower where
 import           Cardano.API.Extended (VotingKeyPublic)
 import           Cardano.Catalyst.Crypto (StakeVerificationKey)
 import           Cardano.Catalyst.Query.Types (Query (..))
-import           Cardano.Catalyst.Registration (Delegations (..), RewardsAddress, Vote,
+import           Cardano.Catalyst.Registration (Delegations (..), VoteRewardsAddress, Vote,
                    catalystPurpose, filterLatestRegistrations, parseRegistration, purposeNumber,
                    voteRegistrationDelegations, voteRegistrationPurpose,
                    voteRegistrationRewardsAddress, voteRegistrationStakeAddress,
@@ -39,7 +39,7 @@ import qualified Data.List.NonEmpty as NE
 data VotingPower
   = VotingPower { _powerDelegations    :: Delegations VotingKeyPublic
                 , _powerStakePublicKey :: StakeVerificationKey
-                , _powerRewardsAddress :: RewardsAddress
+                , _powerRewardsAddress :: VoteRewardsAddress
                 , _powerVotingPower    :: Integer
                 , _powerVotingPurpose  :: Integer
                 }

--- a/src/Config/Snapshot.hs
+++ b/src/Config/Snapshot.hs
@@ -19,7 +19,7 @@ module Config.Snapshot
 
 import           Control.Lens.TH (makeClassyPrisms)
 import           Control.Monad.Except (ExceptT)
-import           Options.Applicative (Parser, ParserInfo, auto, fullDesc, header, help, helper,
+import           Options.Applicative (Parser, ParserInfo, auto, flag, fullDesc, header, help, helper,
                    info, long, metavar, option, optional, progDesc, showDefault, strOption, value,
                    (<**>))
 
@@ -39,6 +39,8 @@ data Config = Config
     -- ^ Slot to view state of, defaults to tip of chain. Queries registrations placed before or equal to (<=) this slotNo.
     , cfgOutFile           :: FilePath
     -- ^ File to output snapshot to
+    , cfgVerbose           :: Bool
+    -- ^ Enable verbose logging
     }
   deriving (Eq, Show)
 
@@ -50,8 +52,8 @@ makeClassyPrisms ''ConfigError
 mkConfig
   :: Opts
   -> ExceptT ConfigError IO Config
-mkConfig (Opts networkId dbName dbUser dbHost dbPass mSlotNo scale outfile) = do
-  pure $ Config networkId scale (DatabaseConfig dbName dbUser dbHost dbPass) mSlotNo outfile
+mkConfig (Opts networkId dbName dbUser dbHost dbPass mSlotNo scale outfile verbose) = do
+  pure $ Config networkId scale (DatabaseConfig dbName dbUser dbHost dbPass) mSlotNo outfile verbose
 
 data Opts = Opts
     { optNetworkId      :: NetworkId
@@ -62,6 +64,7 @@ data Opts = Opts
     , optSlotNo         :: Maybe SlotNo
     , optScale          :: Int
     , optOutFile        :: FilePath
+    , optVerbose        :: Bool
     }
     deriving (Eq, Show)
 
@@ -75,6 +78,7 @@ parseOpts = Opts
   <*> optional pSlotNo
   <*> fmap fromIntegral (option auto (long "scale" <> metavar "DOUBLE" <> showDefault <> value (1 :: Integer) <> help "Scale the voting funds by this amount to arrive at the voting power"))
   <*> strOption (long "out-file" <> metavar "FILE" <> help "File to output the signed transaction to")
+  <*> flag False True (long "verbose" <> help "Adds more verbose logs.")
 
 opts :: ParserInfo Opts
 opts =

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -4,8 +4,7 @@ module Main where
 
 import           Cardano.Catalyst.VotePower (getVoteRegistrationADA)
 import           Control.Monad.Except (runExceptT)
-import           Control.Monad.IO.Class (liftIO)
-import           Control.Monad.Logger (logInfoN, runNoLoggingT)
+import           Control.Monad.Logger (LoggingT, logInfoN, runStdoutLoggingT)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BLC
@@ -35,8 +34,8 @@ main = do
 toJSON :: Aeson.ToJSON a => Aeson.NumberFormat -> a -> BLC.ByteString
 toJSON numFormat = Aeson.encodePretty' (Aeson.defConfig { Aeson.confCompare = Aeson.compare, Aeson.confNumFormat = numFormat })
 
-runQuery :: DatabaseConfig -> SqlPersistT IO a -> IO a
-runQuery dbConfig q = runNoLoggingT $ do
+runQuery :: DatabaseConfig -> SqlPersistT (LoggingT IO) a -> IO a
+runQuery dbConfig q = runStdoutLoggingT $ do
   logInfoN $ T.pack $ "Connecting to database at " <> _dbHost dbConfig
   withPostgresqlConn (pgConnectionString dbConfig) $ \backend -> do
-    liftIO $ runSqlConnWithIsolation q backend Serializable
+    runSqlConnWithIsolation q backend Serializable

--- a/voting-tools.cabal
+++ b/voting-tools.cabal
@@ -65,6 +65,7 @@ library
                      , containers
                      , hedgehog
                      , lens
+                     , monad-logger
                      , mtl
                      , optparse-applicative
                      , ouroboros-network

--- a/voting-tools.cabal
+++ b/voting-tools.cabal
@@ -51,6 +51,7 @@ library
                      , aeson
                      , aeson-pretty
                      , attoparsec
+                     , base16-bytestring == 1.0.1.0
                      , bech32
                      , binary
                      , bytestring
@@ -82,6 +83,7 @@ executable voting-tools
                      , aeson
                      , aeson-pretty
                      , attoparsec
+                     , base16-bytestring
                      , bech32
                      , bytestring
                      , cardano-api


### PR DESCRIPTION
CIp https://github.com/cardano-foundation/CIPs/tree/master/CIP-0036 Fund 10, replaced the reward stake address by a regular shelley address. This pr fixes the expected 61284 -> 3 value of registration metadata, while it still accepts the legacy stake reward address for backwards compatibility. 

Additioanlly it adds more logs, like
```
[Info] Connecting to database at /var/run/postgresql
[Info] Found 976 votes
[Info] Managed to succesfully parse 927 votes
[Info] Found 216 distinct stake keys
[Info] Found 81 of them with valid Shelley address payment credentials, while 135 use legacy stake reward addresses
```

and also introduced the --verbose flag to `voting-tools` for additional logs.

New registrations also require a Shelley addres. The legacy stake reward address is no longer supported.